### PR TITLE
propose using cc for audience targeting. That's what it's there for

### DIFF
--- a/mocks/livefyre/site-post-collection.json
+++ b/mocks/livefyre/site-post-collection.json
@@ -9,11 +9,11 @@
         "id": "urn:livefyre:livefyre.com:collection=321",
         "objectType": "collection",
         "url": "http://www.example.com",
-        "title": "My Collection"
+        "title": "My Collection",
+        "tags": [{
+            "id": "urn:livefyre:cnn.fyre.co:topic=57572",
+            "displayName": "basketball"
+        }]
     },
-    "context": {
-        "personalStream": {
-            "topics": "__TOPICS_PLACEHOLDER__"
-        }
-    }
+    "cc": ["urn:livefyre:livefyre.com:topic=57572"]
 }

--- a/mocks/livefyre/site-post-collection.json
+++ b/mocks/livefyre/site-post-collection.json
@@ -15,5 +15,5 @@
             "displayName": "basketball"
         }]
     },
-    "cc": ["urn:livefyre:livefyre.com:topic=57572"]
+    "cc": ["urn:livefyre:livefyre.com:topic=57572:followers"]
 }

--- a/mocks/livefyre/site-post-collection.json
+++ b/mocks/livefyre/site-post-collection.json
@@ -4,16 +4,28 @@
         "id": "urn:livefyre:livefyre.com:site=222",
         "url": "http://www.example.com"
     },
-    "verb": "verb",
+    "verb": "post",
     "object": {
-        "id": "urn:livefyre:livefyre.com:collection=321",
+        "id": "urn:livefyre:livefyre.com:site=286470:collection=824379",
         "objectType": "collection",
-        "url": "http://www.example.com",
-        "title": "My Collection",
+        "title": "Hello world!",
+        "url": "http://www.demofyre.com/?p=1",
+        "articleId": "1",
+        "site": {
+            "displayName": "site.local",
+            "id": "urn:livefyre:livefyre.com:site=286470",
+            "objectType": "site",
+            "url": "http://site.local/"
+        },
         "tags": [{
-            "id": "urn:livefyre:cnn.fyre.co:topic=57572",
-            "displayName": "basketball"
+            "id": "urn:livefyre:livefyre.com:site=286470:topic=123",
+            "label": "Topic 123",
+            "objectType": "topic"
+        },{
+            "id": "urn:livefyre:livefyre.com:topic=ABC",
+            "label": "Topic ABC - Network",
+            "objectType": "topic"
         }]
     },
-    "cc": ["urn:livefyre:livefyre.com:topic=57572:followers"]
+    "cc": ["urn:livefyre:livefyre.com:site=286470:topic=123"]
 }

--- a/mocks/livefyre/user-post-message.json
+++ b/mocks/livefyre/user-post-message.json
@@ -26,22 +26,26 @@
         }
     },
     "target": {
-        "id": "urn:livefyre:livefyre.com:collection=321",
+        "id": "urn:livefyre:livefyre.com:site=286470:collection=824379",
         "objectType": "collection",
-        "url": "http://www.example.com",
-        "title": "My Collection",
+        "title": "Hello world!",
+        "url": "http://www.demofyre.com/?p=1",
+        "articleId": "1",
         "site": {
-            "id": "urn:livefyre:livefyre.com:site=222",
-            "url": "http://www.example.com"
-        },
-        "network": {
-            "id": "urn:livefyre:livefyre.com:network=333",
-            "displayName": "My Network"
+            "displayName": "site.local",
+            "id": "urn:livefyre:livefyre.com:site=286470",
+            "objectType": "site",
+            "url": "http://site.local/"
         },
         "tags": [{
-            "id": "urn:livefyre:cnn.fyre.co:topic=57572",
-            "displayName": "basketball"
+            "id": "urn:livefyre:livefyre.com:site=286470:topic=123",
+            "label": "Topic 123",
+            "objectType": "topic"
+        },{
+            "id": "urn:livefyre:livefyre.com:topic=ABC",
+            "label": "Topic ABC - Network",
+            "objectType": "topic"
         }]
     },
-    "cc": ["urn:livefyre:livefyre.com:topic=57572:followers"]
+    "cc": ["urn:livefyre:livefyre.com:topic=ABC"]
 }

--- a/mocks/livefyre/user-post-message.json
+++ b/mocks/livefyre/user-post-message.json
@@ -39,11 +39,11 @@
         "network": {
             "id": "urn:livefyre:livefyre.com:network=333",
             "displayName": "My Network"
-        }
+        },
+        "tags": [{
+            "id": "urn:livefyre:cnn.fyre.co:topic=57572",
+            "displayName": "basketball"
+        }]
     },
-    "context": {
-        "personalStream": {
-            "topics": "__TOPICS_PLACEHOLDER__"
-        }
-    }
+    "cc": ["urn:livefyre:livefyre.com:topic=57572"]
 }

--- a/mocks/livefyre/user-post-message.json
+++ b/mocks/livefyre/user-post-message.json
@@ -7,9 +7,7 @@
         "image": "http://www.livefyre.com/user/123/sample.gif",
         "email": "bob@example.com"
     },
-    "published" : {
-        "published_time" : "2014-06-14T20:56:16.046092Z"
-    },
+    "published" : "2014-06-14T20:56:16.046092Z",
     "verb": {
         "id": "urn:livefyre:livefyre.com:verb=post",
         "displayName": "post"

--- a/mocks/livefyre/user-post-message.json
+++ b/mocks/livefyre/user-post-message.json
@@ -45,5 +45,5 @@
             "displayName": "basketball"
         }]
     },
-    "cc": ["urn:livefyre:livefyre.com:topic=57572"]
+    "cc": ["urn:livefyre:livefyre.com:topic=57572:followers"]
 }


### PR DESCRIPTION
I found this post from @jasnell, the spec editor, from October 2013 discussing the subtleties of audience targeting when the set of users you are targeting is large, and maybe a subset of a larger community. Very relevant to our needs.

https://groups.google.com/d/msg/activity-streams/Tg9EJUVa3-o/LvETeZ3Q_BQJ

I think we are doing essentially the same thing here, but instead of the 'cc' audience including `urn:social:interested`, its the followers of a given topic in Livefyre.

This pull would switch to cc from our contrived 'context' key, which is a little too close to '@context' in [JSON-LD](http://www.w3.org/TR/json-ld/#the-context) (IMHO)

@jayv, @jasnell, do you agree?

Quick chat with @ninowalker leads to the supportive (for him) conclusion that this approach is "not one I can find immediate fault with" haha
